### PR TITLE
Add `deny(missing_debug_implementations)` and `deny(missing_docs)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+//! TODO: FIXME: Add some description.
+
+#![deny(missing_debug_implementations)]
+#![deny(missing_docs)]
+
 extern crate regex;
 
 #[cfg(target_os = "android")]


### PR DESCRIPTION
Closes #8.