### PR TITLE
Use `extern "system"` instead of `extern "C"` for `RtlGetVersion` win32 API

### DIFF
--- a/src/windows/winapi.rs
+++ b/src/windows/winapi.rs
@@ -33,7 +33,7 @@ const VER_SUITE_WH_SERVER: u16 = 0x00008000;
 const PROCESSOR_ARCHITECTURE_AMD64: u16 = 9;
 
 #[link(name = "ntdll")]
-extern "C" {
+extern "system" {
     pub fn RtlGetVersion(lpVersionInformation: &mut OSVERSIONINFOEX) -> NTSTATUS;
 }
 


### PR DESCRIPTION
It's a tiny bug fix, but it makes 32-bit windows builds work! I updated the [example repo](https://github.com/dherman/win-os-app) to use my branch and [the build succeeds](https://ci.appveyor.com/project/dherman/win-os-app).

Closes #87.