### PR TITLE
Support serde serialization/deserialization.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ is-it-maintained-open-issues = { repository = "DarkEld3r/os_info" }
 
 [dependencies]
 log = "0.4.1"
+serde = "1.0"
+serde_derive = "1.0"
 
 [target.'cfg(not(windows))'.dependencies]
 regex="0.2.10"

--- a/src/info.rs
+++ b/src/info.rs
@@ -15,7 +15,7 @@ use super::{Type, Version};
 /// let info = os_info::get();
 /// println!("OS information: {}", info);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Info {
     /// Operating system type. See `Type` for details.
     pub(crate) os_type: Type,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ extern crate winapi;
 #[cfg(test)]
 extern crate itertools;
 
+#[macro_use]
+extern crate serde_derive;
+
 #[cfg(target_os = "android")]
 #[path = "android/mod.rs"]
 mod imp;

--- a/src/os_type.rs
+++ b/src/os_type.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display, Formatter};
 
 /// A list of supported operating system types.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum Type {
     /// Unknown operating system.
     Unknown,

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,14 +1,14 @@
 use std::fmt::{self, Display, Formatter, Write};
 
 /// Operating system version including version number and optional edition.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Version {
     pub(crate) version: VersionType,
     pub(crate) edition: Option<String>,
 }
 
 /// Operating system version.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum VersionType {
     /// Unknown version.
     Unknown,


### PR DESCRIPTION
This change adds support for serializing and deserializing the core types in the `os_info` crate using `serde`.