### PR TITLE
deps: upgrade pretty_assertions and itertools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,5 @@ user32-sys = "0.2.0"
 kernel32-sys = "0.2.2"
 
 [dev-dependencies]
-itertools = "0.7.8"
-pretty_assertions = "0.5.1"
+itertools = "0.8.0"
+pretty_assertions = "0.6.1"

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -14,7 +14,7 @@ pub fn current_platform() -> Info {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use Type;
+    use crate::Type;
 
     #[test]
     fn os_type() {


### PR DESCRIPTION
This PR updates itertools and pretty_assertions to the latest versions. Tests passed locally (on Fedora Linux 29) but if there's anything I need to check for other platforms, let me know. 