### PR TITLE
fix: replace trim_right with trim_end

### DIFF
--- a/src/linux/file_release.rs
+++ b/src/linux/file_release.rs
@@ -36,9 +36,9 @@ fn retrieve(distributions: &[ReleaseInfo]) -> Option<Info> {
                 .captures_iter(&file_content)
                 .next()
                 .and_then(|c| c.get(1))
-                .map(|v| v.as_str().trim_right().to_owned())
+                .map(|v| v.as_str().trim_end().to_owned())
         } else {
-            Some(file_content.trim_right().to_string())
+            Some(file_content.trim_end().to_string())
         }.map(|x| Version::custom(x, None))
             .unwrap_or_else(Version::unknown);
 


### PR DESCRIPTION
`trim_right()` was [deprecated in 1.33](https://doc.rust-lang.org/std/string/struct.String.html#method.trim_right) and replaced by `trim_end()`. This PR updates `src/linux/file_release.rs` to use the new `String` API.