### PR TITLE
Add support for parsing Amazon Linux os_info

### DIFF
--- a/src/os_type.rs
+++ b/src/os_type.rs
@@ -25,6 +25,8 @@ pub enum Type {
     Centos,
     /// Fedora (<https://en.wikipedia.org/wiki/Fedora_(operating_system)>)
     Fedora,
+    /// Amazon (<https://en.wikipedia.org/wiki/Amazon_Machine_Image#Amazon_Linux_AMI>)
+    Amazon,
     /// Alpine Linux (<https://en.wikipedia.org/wiki/Alpine_Linux>)
     Alpine,
     /// Mac OS X/OS X/macOS (<https://en.wikipedia.org/wiki/MacOS>).


### PR DESCRIPTION
Amazon Linux comes in two flavors: Amazon Linux 1 and Amazon Linux 2.

Amazon Linux 2 uses a different Distributor ID and release versioning scheme.

Currently, Amazon Linux 2's release version continues to be just a "2", supporting this required changing the version_regex to make the second component optional.