### PR TITLE
Add distinct OS type for RedHatEnterprise and associated test cases.

### DIFF
--- a/src/linux/lsb_release.rs
+++ b/src/linux/lsb_release.rs
@@ -128,15 +128,15 @@ mod tests {
 
     #[test]
     pub fn redhat_enterprise_7() {
-        let parse_results = parse(rhel8_file());
-        assert_eq!(parse_results.distribution, Some("RedhatEnterprise".to_string()));
+        let parse_results = parse(rhel7_file());
+        assert_eq!(parse_results.distribution, Some("RedhatEnterpriseServer".to_string()));
         assert_eq!(parse_results.version, Some("7.7".to_string()));
     }
 
     #[test]
-    pub fn redhat_enterprise_8() {
-        let parse_results = parse(rhel8_file());
-        assert_eq!(parse_results.distribution, Some("RedhatEnterprise".to_string()));
+    pub fn redhat_enterprise_6() {
+        let parse_results = parse(rhel7_file());
+        assert_eq!(parse_results.distribution, Some("RedhatEnterpriseServer".to_string()));
         assert_eq!(parse_results.version, Some("6.10".to_string()));
     }
 

--- a/src/linux/lsb_release.rs
+++ b/src/linux/lsb_release.rs
@@ -135,7 +135,7 @@ mod tests {
 
     #[test]
     pub fn redhat_enterprise_6() {
-        let parse_results = parse(rhel7_file());
+        let parse_results = parse(rhel6_file());
         assert_eq!(parse_results.distribution, Some("RedHatEnterpriseServer".to_string()));
         assert_eq!(parse_results.version, Some("6.10".to_string()));
     }

--- a/src/linux/lsb_release.rs
+++ b/src/linux/lsb_release.rs
@@ -19,7 +19,7 @@ pub fn get() -> Option<Info> {
         Some("Debian") => Info::new(Type::Debian, version),
         Some("Arch") => Info::new(Type::Arch, version),
         Some("CentOS") => Info::new(Type::Centos, version),
-        Some("RedHatEnterprise") | Some("RedHatEnterpriseServer") => Info::new(Type::RedhatEnterprise, version),
+        Some("RedHatEnterprise") | Some("RedHatEnterpriseServer") => Info::new(Type::RedHatEnterprise, version),
         Some("Fedora") => Info::new(Type::Fedora, version),
         Some("Amazon") | Some("AmazonAMI") => Info::new(Type::Amazon, version),
         _ => Info::new(Type::Linux, Version::unknown()),
@@ -122,21 +122,21 @@ mod tests {
     #[test]
     pub fn redhat_enterprise_8() {
         let parse_results = parse(rhel8_file());
-        assert_eq!(parse_results.distribution, Some("RedhatEnterprise".to_string()));
+        assert_eq!(parse_results.distribution, Some("RedHatEnterprise".to_string()));
         assert_eq!(parse_results.version, Some("8.1".to_string()));
     }
 
     #[test]
     pub fn redhat_enterprise_7() {
         let parse_results = parse(rhel7_file());
-        assert_eq!(parse_results.distribution, Some("RedhatEnterpriseServer".to_string()));
+        assert_eq!(parse_results.distribution, Some("RedHatEnterpriseServer".to_string()));
         assert_eq!(parse_results.version, Some("7.7".to_string()));
     }
 
     #[test]
     pub fn redhat_enterprise_6() {
         let parse_results = parse(rhel7_file());
-        assert_eq!(parse_results.distribution, Some("RedhatEnterpriseServer".to_string()));
+        assert_eq!(parse_results.distribution, Some("RedHatEnterpriseServer".to_string()));
         assert_eq!(parse_results.version, Some("6.10".to_string()));
     }
 

--- a/src/linux/lsb_release.rs
+++ b/src/linux/lsb_release.rs
@@ -19,6 +19,7 @@ pub fn get() -> Option<Info> {
         Some("Debian") => Info::new(Type::Debian, version),
         Some("Arch") => Info::new(Type::Arch, version),
         Some("CentOS") => Info::new(Type::Centos, version),
+        Some("RedHatEnterprise") | Some("RedHatEnterpriseServer") => Info::new(Type::RedhatEnterprise, version),
         Some("Fedora") => Info::new(Type::Fedora, version),
         Some("Amazon") | Some("AmazonAMI") => Info::new(Type::Amazon, version),
         _ => Info::new(Type::Linux, Version::unknown()),
@@ -118,6 +119,27 @@ mod tests {
         assert_eq!(parse_results.version, Some("2".to_string()));
     }
 
+    #[test]
+    pub fn redhat_enterprise_8() {
+        let parse_results = parse(rhel8_file());
+        assert_eq!(parse_results.distribution, Some("RedhatEnterprise".to_string()));
+        assert_eq!(parse_results.version, Some("8.1".to_string()));
+    }
+
+    #[test]
+    pub fn redhat_enterprise_7() {
+        let parse_results = parse(rhel8_file());
+        assert_eq!(parse_results.distribution, Some("RedhatEnterprise".to_string()));
+        assert_eq!(parse_results.version, Some("7.7".to_string()));
+    }
+
+    #[test]
+    pub fn redhat_enterprise_8() {
+        let parse_results = parse(rhel8_file());
+        assert_eq!(parse_results.distribution, Some("RedhatEnterprise".to_string()));
+        assert_eq!(parse_results.version, Some("6.10".to_string()));
+    }
+
     fn file() -> &'static str {
         "\nDistributor ID:	Debian\n\
          Description:	Debian GNU/Linux 7.8 (wheezy)\n\
@@ -170,5 +192,31 @@ mod tests {
          "
     }
 
+    fn rhel8_file() -> &'static str {
+        "LSB Version:	:core-4.1-amd64:core-4.1-noarch\n\
+         Distributor ID:	RedHatEnterprise\n\
+         Description:	Red Hat Enterprise Linux release 8.1 (Ootpa)\n\
+         Release:	8.1\n\
+         Codename:	Ootpa\n\
+         "
+    }
+
+    fn rhel7_file() -> &'static str {
+        "LSB Version:	:core-4.1-amd64:core-4.1-noarch\n\
+        Distributor ID:	RedHatEnterpriseServer\n\
+        Description:	Red Hat Enterprise Linux Server release 7.7 (Maipo)\n\
+        Release:	7.7\n\
+        Codename:	Maipo\n\
+        "
+    }
+
+    fn rhel6_file() -> &'static str {
+        "LSB Version:	:base-4.0-amd64:base-4.0-noarch:core-4.0-amd64:core-4.0-noarch:graphics-4.0-amd64:graphics-4.0-noarch:printing-4.0-amd64:printing-4.0-noarch\n\
+        Distributor ID:	RedHatEnterpriseServer\n\
+        Description:	Red Hat Enterprise Linux Server release 6.10 (Santiago)\n\
+        Release:	6.10\n\
+        Codename:	Santiago\n\
+        "
+    }
 }
 

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -25,6 +25,7 @@ mod tests {
         match version.os_type() {
             Type::Linux
             | Type::Redhat
+            | Type::RedHatEnterprise
             | Type::Ubuntu
             | Type::Debian
             | Type::Arch

--- a/src/os_type.rs
+++ b/src/os_type.rs
@@ -15,6 +15,8 @@ pub enum Type {
     Linux,
     /// Red Hat Linux (<https://en.wikipedia.org/wiki/Red_Hat_Linux>).
     Redhat,
+    /// Red Hat Enterprise Linux (<https://en.wikipedia.org/wiki/Red_Hat_Enterprise_Linux>).
+    RedhatEnterprise,
     /// Ubuntu (<https://en.wikipedia.org/wiki/Ubuntu_(operating_system)>).
     Ubuntu,
     /// Debian (<https://en.wikipedia.org/wiki/Debian>).

--- a/src/os_type.rs
+++ b/src/os_type.rs
@@ -16,7 +16,7 @@ pub enum Type {
     /// Red Hat Linux (<https://en.wikipedia.org/wiki/Red_Hat_Linux>).
     Redhat,
     /// Red Hat Enterprise Linux (<https://en.wikipedia.org/wiki/Red_Hat_Enterprise_Linux>).
-    RedhatEnterprise,
+    RedHatEnterprise,
     /// Ubuntu (<https://en.wikipedia.org/wiki/Ubuntu_(operating_system)>).
     Ubuntu,
     /// Debian (<https://en.wikipedia.org/wiki/Debian>).


### PR DESCRIPTION
This change adds support for Red Hat Enterprise Linux and provides test cases for RHEL 6, 7, and 8 (the current actively supported versions). This change mirrors the Centos code in that it relies on `lsb_release` for its version parsing information.

This change creates a new type variant (RedHatEnterprise) which is distinct from Redhat as per Red Hat's nomenclature, the "Red Hat" distribution is defunct as of 2003. It seemed prudent to make the distinction obvious as RHEL is definitely not Red Hat.