### PR TITLE
Remove dependency on regex crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,6 @@ default = ["serde"]
 log = "0.4.5"
 serde = { version = "1.0.0", features = ["derive"], optional = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-lazy_static = "1.1.0"
-
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", features = ["minwindef", "ntdef", "ntstatus", "sysinfoapi", "winnt", "winuser", "libloaderapi", "processthreadsapi"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,6 @@ default = ["serde"]
 log = "0.4.5"
 serde = { version = "1.0.0", features = ["derive"], optional = true }
 
-[target.'cfg(not(windows))'.dependencies]
-regex="1.0.5"
-
 [target.'cfg(target_os = "macos")'.dependencies]
 lazy_static = "1.1.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,12 +42,14 @@ mod imp;
 
 mod bitness;
 mod info;
+#[cfg(not(windows))]
 mod matcher;
 mod os_type;
 mod version;
 
 pub use bitness::Bitness;
 pub use info::Info;
+#[cfg(not(windows))]
 use matcher::Matcher;
 pub use os_type::Type;
 pub use version::{Version, VersionType};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,11 +42,13 @@ mod imp;
 
 mod bitness;
 mod info;
+mod matcher;
 mod os_type;
 mod version;
 
 pub use bitness::Bitness;
 pub use info::Info;
+use matcher::Matcher;
 pub use os_type::Type;
 pub use version::{Version, VersionType};
 

--- a/src/linux/lsb_release.rs
+++ b/src/linux/lsb_release.rs
@@ -3,9 +3,8 @@
 use std::process::Command;
 
 use log::{trace, warn};
-use regex::Regex;
 
-use crate::{Bitness, Info, Type, Version};
+use crate::{Bitness, Info, Matcher, Type, Version};
 
 pub fn get() -> Option<Info> {
     let release = retrieve()?;
@@ -51,19 +50,12 @@ fn retrieve() -> Option<LsbRelease> {
 fn parse(output: &str) -> LsbRelease {
     trace!("Trying to parse {:?}", output);
 
-    let distribution_regex = Regex::new(r"Distributor ID:\s(\w+)").unwrap();
-    let distribution = distribution_regex
-        .captures_iter(output)
-        .next()
-        .and_then(|c| c.get(1))
-        .map(|d| d.as_str().to_owned());
+    let distribution = Matcher::PrefixedWord {
+        prefix: "Distributor ID:",
+    }
+    .find(output);
 
-    let version_regex = Regex::new(r"Release:\s+([\w]+[.]?[\w]*)?").unwrap();
-    let version = version_regex
-        .captures_iter(output)
-        .next()
-        .and_then(|c| c.get(1))
-        .map(|v| v.as_str().to_owned());
+    let version = Matcher::PrefixedVersion { prefix: "Release:" }.find(output);
 
     trace!(
         "Parsed as '{:?}' distribution and '{:?}' version",

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -2,9 +2,8 @@ use std::process::Command;
 
 use lazy_static::lazy_static;
 use log::trace;
-use regex::Regex;
 
-use crate::{Bitness, Info, Type, Version};
+use crate::{Bitness, Info, Matcher, Type, Version};
 
 pub fn current_platform() -> Info {
     trace!("macos::current_platform is called");
@@ -60,17 +59,10 @@ fn product_version() -> Option<String> {
 }
 
 fn parse(sw_vers_output: &str) -> Option<String> {
-    lazy_static! {
-        static ref VERSION: Regex = Regex::new(r"ProductVersion:\s(\w+\.\w+(\.\w+)?)").unwrap();
+    Matcher::PrefixedVersion {
+        prefix: "ProductVersion:",
     }
-
-    Some(
-        VERSION
-            .captures(sw_vers_output)?
-            .get(1)?
-            .as_str()
-            .to_owned(),
-    )
+    .find(sw_vers_output)
 }
 
 #[cfg(test)]

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,6 +1,5 @@
 use std::process::Command;
 
-use lazy_static::lazy_static;
 use log::trace;
 
 use crate::{Bitness, Info, Matcher, Type, Version};

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,0 +1,48 @@
+/// An implementation to match on simple strings.
+#[derive(Debug, Clone)]
+pub(crate) enum Matcher {
+    /// Considers the entire string (trimmed) to be the match.
+    AllTrimmed,
+
+    /// After finding the `prefix` followed by one or more spaces, returns the following word.
+    PrefixedWord { prefix: &'static str },
+
+    /// Similar to `PrefixedWord`, but only if the word is a valid version.
+    PrefixedVersion { prefix: &'static str },
+}
+
+fn find_prefixed_word<'a>(string: &'a str, prefix: &str) -> Option<&'a str> {
+    if let Some(prefix_start) = string.find(prefix) {
+        // Ignore prefix and leading whitespace
+        let string = &string[prefix_start + prefix.len()..].trim_start();
+
+        // Find where the word boundary ends
+        let word_end = string
+            .find(|c: char| c.is_whitespace())
+            .unwrap_or_else(|| string.len());
+        let string = &string[..word_end];
+
+        Some(string)
+    } else {
+        None
+    }
+}
+
+fn is_valid_version(word: &str) -> bool {
+    !word.starts_with('.') && !word.ends_with('.')
+}
+
+impl Matcher {
+    /// Find the match on the input `string`.
+    pub(crate) fn find(&self, string: &str) -> Option<String> {
+        match *self {
+            Self::AllTrimmed => Some(string.trim().to_string()),
+            Self::PrefixedWord { prefix } => {
+                find_prefixed_word(string, prefix).map(|v| v.to_owned())
+            }
+            Self::PrefixedVersion { prefix } => find_prefixed_word(string, prefix)
+                .filter(|&v| is_valid_version(v))
+                .map(|v| v.to_owned()),
+        }
+    }
+}


### PR DESCRIPTION
Fixes #142.

I haven't added tests on the `Matcher` because the different matching is tested on the different `parse` functions. Please let me know if I should include tests for the `Matcher`.

I don't have a macOS, so I'm not sure what the right way to test that is. What I did was temporarily copy relevant tests and the new function to somewhere else where I could compile and run them. It compiles, and they work, but please let me know what the proper way to test this is.

I should note, the `Matcher` does not work exactly like the old regex did. It's more of a `\S+` rather than `[\w.]+`, but since all tests pass, it should be fine. Furthermore, there is no need to `trim`, since neither the regex or now the `Matcher` would ever include whitespace in the captured group!