### PR TITLE
Add manjaro linux support

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -12,3 +12,4 @@ structopt
 toml
 winapi
 xenial
+manjaro

--- a/os_info/src/info.rs
+++ b/os_info/src/info.rs
@@ -157,6 +157,7 @@ mod tests {
             Type::Arch,
             Type::Centos,
             Type::Fedora,
+            Type::Manjaro,
             Type::Alpine,
             Type::Macos,
             Type::Redox,

--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -336,7 +336,7 @@ mod tests {
         Distributor ID: ManjaroLinux\n\
         Description:    Manjaro Linux\n\
         Release:        19.0.2\n\
-        Codename:       Kyria\n\
+        Codename:       n/a\n\
         "
     }
 }

--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -25,6 +25,7 @@ pub fn get() -> Option<Info> {
         Some("SUSE") => Type::SUSE,
         Some("openSUSE") => Type::openSUSE,
         Some("OracleServer") => Type::OracleLinux,
+        Some("ManjaroLinux") => Type::Manjaro,
         _ => Type::Linux,
     };
 
@@ -190,6 +191,13 @@ mod tests {
         assert_eq!(parse_results.version, Some("20.04".to_string()));
     }
 
+    #[test]
+    pub fn manjaro() {
+        let parse_results = parse(manjaro_19_0_2_file());
+        assert_eq!(parse_results.distribution, Some("ManjaroLinux".to_string()));
+        assert_eq!(parse_results.version, Some("19.0.2".to_string()));
+    }
+
     fn file() -> &'static str {
         "\nDistributor ID:	Debian\n\
          Description:	Debian GNU/Linux 7.8 (wheezy)\n\
@@ -320,6 +328,15 @@ mod tests {
         Description: Pop!_OS 20.04 LTS\n\
         Release: 20.04\n\
         Codename: focal\n\
+        "
+    }
+
+    fn manjaro_19_0_2_file() -> &'static str {
+        "LSB Version:    n/a\n\
+        Distributor ID: ManjaroLinux\n\
+        Description:    Manjaro Linux\n\
+        Release:        19.0.2\n\
+        Codename:       Kyria\n\
         "
     }
 }

--- a/os_info/src/linux/mod.rs
+++ b/os_info/src/linux/mod.rs
@@ -50,6 +50,7 @@ mod tests {
             | Type::SUSE
             | Type::openSUSE
             | Type::OracleLinux
+            | Type::Manjaro
             | Type::Alpine => (),
             os_type => {
                 panic!("Unexpected OS type: {}", os_type);

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -40,6 +40,8 @@ pub enum Type {
     Alpine,
     /// Oracle Linux Server (<https://en.wikipedia.org/wiki/Oracle_Linux>).
     OracleLinux,
+    /// Manjaro (<https://en.wikipedia.org/wiki/Manjaro>).
+    Manjaro,
     /// Mac OS X/OS X/macOS (<https://en.wikipedia.org/wiki/MacOS>).
     Macos,
     /// Redox (<https://en.wikipedia.org/wiki/Redox_(operating_system)>).


### PR DESCRIPTION
Hey @DarkEld3r,
I just run into the crate, a good one by the way :), and find out that there's no manjaro in the list, which I am on now.

This PR is add the manjaro support.

The only thing that I am not sure in what order I should have put the `Manjaro` in the enums. And I hope I added all the necessary tests.

before
```text
OS information:
Type: Linux
Version: 19.0.2
Bitness: 64-bit
``` 

after
```text
OS information:
Type: Manjaro
Version: 19.0.2
Bitness: 64-bit
```

CI comment: Should I add `manjaro` to `spell-checker:ignore` comments?`