### PR TITLE
Add solus support

### DIFF
--- a/os_info/src/info.rs
+++ b/os_info/src/info.rs
@@ -157,6 +157,7 @@ mod tests {
             Type::Arch,
             Type::Centos,
             Type::Fedora,
+            Type::Solus,
             Type::Alpine,
             Type::Macos,
             Type::Redox,

--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -345,6 +345,7 @@ mod tests {
         Description:	Solus\n\
         Release:	4.1\n\
         Codename:	fortitude\n\
+        "
     }
 
     fn manjaro_19_0_2_file() -> &'static str {

--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -21,6 +21,7 @@ pub fn get() -> Option<Info> {
         Some("CentOS") => Type::Centos,
         Some("RedHatEnterprise") | Some("RedHatEnterpriseServer") => Type::RedHatEnterprise,
         Some("Fedora") => Type::Fedora,
+        Some("Solus") => Type::Solus,
         Some("Amazon") | Some("AmazonAMI") => Type::Amazon,
         Some("SUSE") => Type::SUSE,
         Some("openSUSE") => Type::openSUSE,
@@ -190,6 +191,13 @@ mod tests {
         assert_eq!(parse_results.version, Some("20.04".to_string()));
     }
 
+    #[test]
+    pub fn solus_4_1() {
+        let parse_results = parse(solus_4_1_file());
+        assert_eq!(parse_results.distribution, Some("Solus".to_string()));
+        assert_eq!(parse_results.version, Some("4.1".to_string()));
+    }
+
     fn file() -> &'static str {
         "\nDistributor ID:	Debian\n\
          Description:	Debian GNU/Linux 7.8 (wheezy)\n\
@@ -320,6 +328,15 @@ mod tests {
         Description: Pop!_OS 20.04 LTS\n\
         Release: 20.04\n\
         Codename: focal\n\
+        "
+    }
+
+    fn solus_4_1_file() -> &'static str {
+        "LSB Version:	1.4\n\
+        Distributor ID:	Solus\n\
+        Description:	Solus\n\
+        Release:	4.1\n\
+        Codename:	fortitude\n\
         "
     }
 }

--- a/os_info/src/linux/mod.rs
+++ b/os_info/src/linux/mod.rs
@@ -50,6 +50,7 @@ mod tests {
             | Type::SUSE
             | Type::openSUSE
             | Type::OracleLinux
+            | Type::Solus
             | Type::Alpine => (),
             os_type => {
                 panic!("Unexpected OS type: {}", os_type);

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -40,6 +40,8 @@ pub enum Type {
     Alpine,
     /// Oracle Linux Server (<https://en.wikipedia.org/wiki/Oracle_Linux>).
     OracleLinux,
+    /// Solus (<https://en.wikipedia.org/wiki/Solus_(operating_system)>).
+    Solus,
     /// Mac OS X/OS X/macOS (<https://en.wikipedia.org/wiki/MacOS>).
     Macos,
     /// Redox (<https://en.wikipedia.org/wiki/Redox_(operating_system)>).


### PR DESCRIPTION
I got a chance to test it on solus.

before
```
OS information:
Type: Linux
Version: 4.1
Bitness: 64-bit
```

now
```
OS information:
Type: Solus
Version: 4.1
Bitness: 64-bit
```