### PR TITLE
Remove the deps.rs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 **Project details:**
 [![LoC](https://tokei.rs/b1/github/darkeld3r/os_info)](https://github.com/darkeld3r/os_info)
 ![rust 1.41+ required](https://img.shields.io/badge/rust-1.41+-blue.svg?label=Required%20Rust)
-[![dependency status](https://deps.rs/repo/github/darkeld3r/os_info/status.svg)](https://deps.rs/repo/github/darkeld3r/os_info)
 
 ## Overview
 


### PR DESCRIPTION
Closes #179 

Unfortunately, deps.rs is no longer maintained and unable to report the status for this crate. See https://github.com/srijs/deps.rs/issues/41 for details. 