### PR TITLE
Remove codecov badge from the readme

### DIFF
--- a/os_info/Cargo.toml
+++ b/os_info/Cargo.toml
@@ -13,7 +13,6 @@ license = "MIT"
 edition = "2018"
 
 [badges]
-codecov = { repository = "DarkEld3r/os_info", branch = "master", service = "github" }
 is-it-maintained-issue-resolution = { repository = "DarkEld3r/os_info" }
 is-it-maintained-open-issues = { repository = "DarkEld3r/os_info" }
 


### PR DESCRIPTION
The badges are deprecated (see https://github.com/rust-lang/crates.io/issues/2436 for details), except for the maintenance ones.