### PR TITLE
Recognise Arch Linux when using file release

### DIFF
--- a/os_info/src/linux/file_release.rs
+++ b/os_info/src/linux/file_release.rs
@@ -48,6 +48,7 @@ fn retrieve(distributions: &[ReleaseInfo]) -> Option<Info> {
 
 fn get_type(name: &str) -> Option<Type> {
     match name.to_lowercase().as_ref() {
+        "arch linux" => Some(Type::Arch),
         "centos linux" => Some(Type::Centos),
         "ubuntu" => Some(Type::Ubuntu),
         _ => None,


### PR DESCRIPTION
It (unfortunately) uses the same path as Oracle Linux:

https://github.com/DarkEld3r/os_info/blob/f9088845198fa9951f6d97a7bb35d035046f707b/os_info/src/linux/file_release.rs#L72-L76

However just detecting the type name helps avoid it being mis-assigned (I guess ideally we would do this for *all* other types but I only have access to an Arch machine at the moment).

I would also make it detect `BUILD_ID` (instead of `VERSION_ID`), maybe with some form of "alternative matcher", but there are other issues with that (#207).