### PR TITLE
add support of endeavourOS

### DIFF
--- a/os_info/src/info.rs
+++ b/os_info/src/info.rs
@@ -158,6 +158,7 @@ mod tests {
             Type::Centos,
             Type::Fedora,
             Type::Solus,
+            Type::EndeavourOS,
             Type::Manjaro,
             Type::Alpine,
             Type::Macos,

--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -22,6 +22,7 @@ pub fn get() -> Option<Info> {
         Some("RedHatEnterprise") | Some("RedHatEnterpriseServer") => Type::RedHatEnterprise,
         Some("Fedora") => Type::Fedora,
         Some("Solus") => Type::Solus,
+        Some("EndeavourOS") => Type::EndeavourOS,
         Some("Amazon") | Some("AmazonAMI") => Type::Amazon,
         Some("SUSE") => Type::SUSE,
         Some("openSUSE") => Type::openSUSE,
@@ -206,6 +207,13 @@ mod tests {
         assert_eq!(parse_results.version, Some("19.0.2".to_string()));
     }
 
+    #[test]
+    fn endeavouros() {
+        let parse_results = parse(endeavouros_file());
+        assert_eq!(parse_results.distribution, Some("EndeavourOS".to_string()));
+        assert_eq!(parse_results.version, Some("rolling".to_string()));
+    }
+
     fn file() -> &'static str {
         "\nDistributor ID:	Debian\n\
          Description:	Debian GNU/Linux 7.8 (wheezy)\n\
@@ -354,6 +362,15 @@ mod tests {
         Description:    Manjaro Linux\n\
         Release:        19.0.2\n\
         Codename:       n/a\n\
+        "
+    }
+
+    fn endeavouros_file() -> &'static str {
+        "LSB Version:	1.4\n\
+        Distributor ID:	EndeavourOS\n\
+        Description:	EndeavourOS Linux\n\
+        Release:	rolling\n\
+        Codename:	n/a\n\
         "
     }
 }

--- a/os_info/src/linux/mod.rs
+++ b/os_info/src/linux/mod.rs
@@ -38,6 +38,7 @@ mod tests {
             | Type::openSUSE
             | Type::OracleLinux
             | Type::Solus
+            | Type::EndeavourOS
             | Type::Manjaro
             | Type::Alpine => (),
             os_type => {

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -42,6 +42,8 @@ pub enum Type {
     Redox,
     /// Solus (<https://en.wikipedia.org/wiki/Solus_(operating_system)>).
     Solus,
+    /// EndeavourOS (<https://en.wikipedia.org/wiki/EndeavourOS>).
+    EndeavourOS,
     /// SUSE Linux Enterprise Server (<https://en.wikipedia.org/wiki/SUSE_Linux_Enterprise>).
     SUSE,
     /// Ubuntu (<https://en.wikipedia.org/wiki/Ubuntu_(operating_system)>).


### PR DESCRIPTION
https://en.wikipedia.org/wiki/EndeavourOS

```
cargo run --example print_version
    Finished dev [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/examples/print_version`
OS information: EndeavourOS (rolling) (64-bit)
Type: EndeavourOS
Version: rolling
Bitness: 64-bit
```